### PR TITLE
Changes to support deployment on EB

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,8 @@ jspm_packages
 *.swp
 
 env_variables
+
+# Elastic Beanstalk Files
+.elasticbeanstalk/*
+!.elasticbeanstalk/*.cfg.yml
+!.elasticbeanstalk/*.global.yml

--- a/app.js
+++ b/app.js
@@ -1,9 +1,9 @@
 var Twit = require('twit');
 var path = require('path');
 var slackbot = require('node-slackbot');
-require('dotenv').config({
-	path: path.resolve('./env_variables')
-});
+// require('dotenv').config({
+// 	path: path.resolve('./env_variables')
+// });
 
 var T = new Twit({
 	consumer_key: process.env.TWITTER_CONSUMER_KEY,

--- a/app.js
+++ b/app.js
@@ -1,9 +1,10 @@
 var Twit = require('twit');
 var path = require('path');
 var slackbot = require('node-slackbot');
-// require('dotenv').config({
-// 	path: path.resolve('./env_variables')
-// });
+require('dotenv').config({
+	path: path.resolve('./env_variables'),
+	silent: true
+});
 
 var T = new Twit({
 	consumer_key: process.env.TWITTER_CONSUMER_KEY,


### PR DESCRIPTION
* Change bot script name from hurrslack.js to app.js to follow EB convention
* Add EB directory to .gitignore
* Ignore env_variables if doesn't exist (in EB these are set in the console). With this change, developers will not see a useful error message if they forget to set up their environment, so I'm open to a better solution.