### PR TITLE
feat(lots): more tests, a strategy pattern, and posting images

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,4 +1,8 @@
 var path = require('path');
+var https = require('https');
+var url = require('url');
+var assign = require('lodash.assign');
+var concat = require('concat-stream');
 var Slackbot = require('./slackbot');
 var TwitterPoster = require('./twitter');
 var createFakeScreenshot = require('./create-fake-screenshot');
@@ -13,28 +17,68 @@ require('dotenv').config({
 
 var bot = Slackbot(env);
 var tweeter = TwitterPoster(env);
+var log = helpers.logger('App', env.isDev);
 
-bot.onPinAdded(function (message, channelData) {
-  console.log('received pin', JSON.stringify(message.item, null, 2));
-  var channel = channelData.channel;
-  if (!channel.is_member) {
-    console.log(
-      'pin was in channel #' + channel.name + ', of which i am not a member'
-    );
-    return;
-  }
-  console.log(
-    'pin was in channel #' + channel.name + ', of which i am a member. post!'
-  );
+function postText (message) {
   var text = message.item.message && message.item.message.text;
   if (text && text.length <= 140) {
     tweeter.postTweet(text);
   } else if (text && text.length > 140) {
-    console.log('generating tweet for text > 140 characters');
+    log('generating tweet for text > 140 characters');
     var trimmedText = text.substring(0, 110) + '…';
     var imageData = createFakeScreenshot(text);
     tweeter.postTweetAndImage(imageData, trimmedText);
   }
+}
+
+function postFile (message, next) {
+  bot.getFileInfo(message.item.file_id, function onFileInfo (info) {
+    getImage(info.thumb_960 || info.thumb_480 || info.url_private);
+    function getImage (uri) {
+      var options = assign(url.parse(uri), {
+        headers: {
+          'Authorization': 'Bearer ' + env.vars.SLACK_TOKEN
+        }
+      });
+      log('requesting file: ', options);
+      https.get(options, function streamResponse (res) {
+        if (res.statusCode >= 300 && res.statusCode <= 400) {
+          log('redirected to', res.headers.location);
+          return getImage(res.headers.location);
+        }
+        if (res.statusCode !== 200) {
+          throw Error(
+            'Status code ' + res.statusCode + ' returned for file ' + url
+          );
+        }
+        res.setEncoding('base64');
+        res.pipe(concat(function sendImageData (data) {
+          log('sending image data to tweeter');
+          tweeter.postTweetAndImage(data, info.title);
+        }));
+      });
+    }
+  });
+}
+
+var postingStrategies = {
+  message: postText,
+  file: postFile
+};
+
+bot.onPinAdded(function (message, channelData) {
+  var channel = channelData.channel;
+  if (!channel.is_member) {
+    log('pin was in #' + channel.name + ', of which i am not a member');
+    return;
+  }
+  log('pin was in #' + channel.name + ', of which i am a member. posting...');
+  var post = postingStrategies[message.item.type];
+  if (!post) {
+    var resText = JSON.stringify(message);
+    throw Error('No strategy to handle this type of pin: ' + resText);
+  }
+  post(message);
 });
 
 bot.connect(function onConnected (data) {

--- a/helpers.js
+++ b/helpers.js
@@ -8,6 +8,9 @@ function handleError (next) {
 }
 
 function getEnv (process) {
+  if (!process) {
+    process = { env: {} };
+  }
   return {
     vars: process.env,
     isDev: process.env.NODE_ENV === 'development',
@@ -15,7 +18,26 @@ function getEnv (process) {
   };
 }
 
+function logger (tag, works) {
+  var log;
+  if (!tag.match(/:\s*$/)) {
+    tag += ': ';
+  }
+  if (works !== false) {
+    log = function log () {
+      console.log.apply(console, [tag].concat([].slice.call(arguments)));
+    };
+  } else {
+    log = function noop () {};
+  }
+  log.sub = function (subtag, works) {
+    return logger(tag + subtag, works);
+  };
+  return log;
+}
+
 module.exports = {
   handleError: handleError,
-  getEnv: getEnv
+  getEnv: getEnv,
+  logger: logger
 };

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@slack/client": "^3.5.1",
     "canvas": "^1.4.0",
     "canvas-text-wrapper": "^0.9.2",
+    "concat-stream": "^1.5.1",
     "cross-env": "^2.0.0",
     "dotenv": "^2.0.0",
     "lodash.assign": "^4.0.9",

--- a/slackbot.js
+++ b/slackbot.js
@@ -1,30 +1,49 @@
 var slack = require('@slack/client');
+var assign = require('lodash.assign');
 var helpers = require('./helpers');
 
-function Slackbot (env) {
-  var clientOpts = env.isProd ? {} : { logLevel: 'verbose' };
+function Slackbot (env, opts) {
+  var defaultOpts = env.isProd ? {} : { logLevel: 'verbose' };
+  var clientOpts = opts ? defaultOpts : assign(defaultOpts, opts);
+  var verbose = helpers.logger('Slackbot', clientOpts.logLevel === 'verbose');
   var rtm = new slack.RtmClient(env.vars.SLACK_TOKEN, clientOpts);
   var web = new slack.WebClient(env.vars.SLACK_TOKEN, clientOpts);
   function includeChannel (next) {
+    var yak = verbose.sub('includeChannel');
     return function addChannelToResponse (response) {
       if (!response.channel_id) {
+        yak('no channel_id found, will not place call', response);
         return next(response);
       }
+      yak('channel_id found in response, get info for', response.channel_id);
       return web.channels.info(
         response.channel_id,
         helpers.handleError(function (channelRes) {
+          yak('channel response for', response.channel_id, channelRes);
           next(response, channelRes);
         }));
     };
   }
+  function getFileInfo (id, next) {
+    var yak = verbose.sub('getFileInfo');
+    yak('getting file', id);
+    web.files.info(id, helpers.handleError(function (res) {
+      yak('received file', res.file);
+      next(res.file);
+    }));
+  }
   function onPinAdded (next) {
-    rtm.on(slack.RTM_EVENTS.PIN_ADDED, includeChannel(next));
+    rtm.on(slack.RTM_EVENTS.PIN_ADDED, includeChannel(function (res, chan) {
+      verbose('onPinAdded', res);
+      next.call(this, res, chan);
+    }));
   }
   function connect (next) {
     rtm.on(slack.CLIENT_EVENTS.RTM.AUTHENTICATED, next);
     rtm.start();
   }
   return {
+    getFileInfo: getFileInfo,
     onPinAdded: onPinAdded,
     connect: connect
   };

--- a/test/helpers.test.js
+++ b/test/helpers.test.js
@@ -1,4 +1,4 @@
-/* global describe, it */
+/* global describe, it, beforeEach, afterEach */
 var chai = require('chai');
 var sinon = require('sinon');
 var helpers = require('../helpers');
@@ -21,36 +21,33 @@ describe('the helper module', function () {
         assertions();
       }, 15);
     }
-    describe('calls them on success', function () {
-      it('with no `null` error argument', function (done) {
-        // notice this doesn't take "err" as its first argument
-        var successOnlyHandler = sinon.spy(function (data) {
-          data.should.not.be.null;
-          data.should.be.an('object');
-          data.should.have.property('foo').that.equals('bar');
-        });
-        var handler = helpers.handleError(successOnlyHandler);
-        runAsync(handler, [null, successData], function () {
-          successOnlyHandler.calledOnce.should.be.true;
-          successOnlyHandler.calledWithExactly(successData).should.be.true;
-          done();
-        });
+    it('calls them on success with no `null` error argument', function (done) {
+      // notice this doesn't take "err" as its first argument
+      var successOnlyHandler = sinon.spy(function (data) {
+        data.should.not.be.null;
+        data.should.be.an('object');
+        data.should.have.property('foo').that.equals('bar');
       });
-      it('with an arbitrary number of arguments', function (done) {
-        // notice this doesn't take "err" as its first argument
-        var arbitraryArgsHandler = sinon.spy(function (data, extraArg) {
-          data.should.equal(successData);
-          extraArg.should.equal(secondArg);
-        });
-        var handler = helpers.handleError(arbitraryArgsHandler);
-        runAsync(handler, [null, successData, secondArg], function () {
-          arbitraryArgsHandler.calledOnce.should.be.true;
-          arbitraryArgsHandler.calledWithExactly(
-            successData,
-            secondArg
-          ).should.be.true;
-          done();
-        });
+      var handler = helpers.handleError(successOnlyHandler);
+      runAsync(handler, [null, successData], function () {
+        successOnlyHandler.calledOnce.should.be.true;
+        successOnlyHandler.calledWithExactly(successData).should.be.true;
+        done();
+      });
+    });
+    it('passes an arbitrary number of arguments after err', function (done) {
+      var arbitraryArgsHandler = sinon.spy(function (data, extraArg) {
+        data.should.equal(successData);
+        extraArg.should.equal(secondArg);
+      });
+      var handler = helpers.handleError(arbitraryArgsHandler);
+      runAsync(handler, [null, successData, secondArg], function () {
+        arbitraryArgsHandler.calledOnce.should.be.true;
+        arbitraryArgsHandler.calledWithExactly(
+          successData,
+          secondArg
+        ).should.be.true;
+        done();
       });
     });
     it('throws an exception when the first arg exists', function (done) {
@@ -63,6 +60,96 @@ describe('the helper module', function () {
         handler.threw(exception).should.be.true;
         done();
       });
+    });
+  });
+  describe('includes `getEnv`, which takes a process global and', function () {
+    var fakeProd = {
+      env: {
+        NODE_ENV: 'production'
+      }
+    };
+    var fakeDev = {
+      env: {
+        NODE_ENV: 'development'
+      }
+    };
+    var fakeAmbig = {
+      env: {}
+    };
+    it('returns a `vars` collection equal to process.env', function () {
+      helpers.getEnv(process).vars.should.equal(process.env);
+    });
+    it(
+      'returns an `isProd` bool for `process.env.NODE_ENV === "production"`',
+      function () {
+        helpers.getEnv(fakeProd).isDev.should.be.false;
+        helpers.getEnv(fakeDev).isDev.should.be.true;
+        helpers.getEnv(fakeAmbig).isDev.should.be.false;
+      }
+    );
+    it(
+      'returns an `isDev` bool for `process.env.NODE_ENV === "development"`',
+      function () {
+        helpers.getEnv(fakeProd).isProd.should.be.true;
+        helpers.getEnv(fakeProd).isDev.should.be.false;
+        helpers.getEnv(fakeAmbig).isDev.should.be.false;
+      }
+    );
+    it('returns blank vars and false bools when passed nothing', function () {
+      var blankEnv = helpers.getEnv();
+      blankEnv.vars.should.be.an('object');
+      blankEnv.vars.should.be.empty;
+      blankEnv.isDev.should.be.false;
+      blankEnv.isProd.should.be.false;
+    });
+  });
+  describe('includes `logger`, which creates a log object that', function () {
+    var log, spy;
+    var sampleObj = { isAn: 'object' };
+    var sampleArray = ['is', 'an', 'array'];
+    beforeEach(function () {
+      log = helpers.logger('Test');
+      spy = sinon.spy(console, 'log');
+    });
+    afterEach(function () {
+      console.log.restore();
+    });
+    it('is a function', function () { log.should.be.a('function'); });
+    it('logs to the console with the tag prefix when called', function () {
+      log('string argument');
+      spy.calledWithExactly('Test: ', 'string argument').should.be.true;
+    });
+    it('does nothing if its second factory arg was false, to allow loglevels',
+      function () {
+        var noLog = helpers.logger('Test', false);
+        noLog('anything');
+        spy.called.should.be.false;
+      }
+    );
+    it('logs multiple arguments with the string prefix as first', function () {
+      log('string argument', sampleObj, sampleArray);
+      spy.calledWithExactly(
+        'Test: ',
+        'string argument',
+        sampleObj,
+        sampleArray
+      ).should.be.true;
+    });
+    it(
+      'has a `.sub` method that spawns another logger with prefix appended',
+      function () {
+        log.sub.should.be.a('function');
+        var sublog = log.sub('Subtest');
+        sublog(sampleObj);
+        spy.withArgs('Test: Subtest: ').calledOnce.should.be.true;
+      }
+    );
+    it('can nest these subloggers to arbitrary depth', function () {
+      var sublog = log.sub('Subtest');
+      sublog.sub.should.be.a('function');
+      var subsublog = sublog.sub('SubSubtest');
+      subsublog(sampleObj);
+      spy.withArgs('Test: Subtest: SubSubtest: ').calledOnce.should.be.true;
     });
   });
 });

--- a/test/slackbot.test.js
+++ b/test/slackbot.test.js
@@ -1,0 +1,37 @@
+/* global describe, it, beforeEach */
+var nock = require('nock');
+var Slackbot = require('../slackbot');
+var helpers = require('../helpers');
+
+var slackApiOrigin = 'https://slack.com:443';
+var env = helpers.getEnv({
+  env: {
+    SLACK_TOKEN: 'test-token',
+    NODE_ENV: 'development'
+  }
+});
+
+describe('the slackbot factory', function () {
+  var bot;
+  beforeEach(function () {
+    bot = Slackbot(env);
+  });
+  it('returns a slackbot API interface', function () {
+    bot.should.be.an('object');
+    bot.should.respondTo('connect');
+    bot.should.respondTo('onPinAdded');
+    bot.should.respondTo('getFileInfo');
+  });
+  it('gets a file by id', function (done) {
+    this.timeout(10000);
+    nock(slackApiOrigin)
+      .log(console.log)
+      .post('/api/files.info', /test\-file/)
+      .reply(200, { ok: true, file: { foo: 'bar' } });
+    bot.getFileInfo('test-file', function (file) {
+      nock.isDone().should.be.true;
+      file.should.have.property('foo').equals('bar');
+      done();
+    });
+  });
+});


### PR DESCRIPTION
 - implement image posting to twitter
 - add a logger interface to keep log messages organized
 - slightly reorganize tests to @jotok's semantic preferences
 - add more helpers tests
 - add a stub of slackbot tests to demonstrate nock mocking
 - reorganize `onPinAdded` handler in `app.js` into a strategy
 - separate text posting and image posting into strategies

![image](https://cloud.githubusercontent.com/assets/1643758/17087280/1e6eb5a8-51cc-11e6-9f2f-45428c4b7161.png)

describes the picture, but not the code