### PR TITLE
refactor slackbot class to make it easier to test

### DIFF
--- a/app.js
+++ b/app.js
@@ -3,7 +3,7 @@ var https = require('https');
 var url = require('url');
 var assign = require('lodash.assign');
 var concat = require('concat-stream');
-var slackbot = require('./slackbot');
+var Slackbot = require('./slackbot');
 var TwitterPoster = require('./twitter');
 var createFakeScreenshot = require('./create-fake-screenshot');
 var helpers = require('./helpers');
@@ -15,7 +15,7 @@ require('dotenv').config({
   silent: env.vars.NODE_ENV !== 'development'
 });
 
-var bot = slackbot.Slackbot(require('@slack/client'), env);
+var bot = Slackbot(require('@slack/client'), env);
 var tweeter = TwitterPoster(env);
 var log = helpers.logger('App', env.isDev);
 

--- a/app.js
+++ b/app.js
@@ -15,14 +15,7 @@ require('dotenv').config({
   silent: env.vars.NODE_ENV !== 'development'
 });
 
-var bot = (function () {
-  var rtm = slackbot.getSlackRtmClient(env);
-  var web = slackbot.getSlackWebClient(env);
-  var verbose = slackbot.getLogger(env);
-  return slackbot.Slackbot(rtm, web, verbose);
-})();
-
-// var bot = Slackbot(env);
+var bot = slackbot.Slackbot(require('@slack/client'), env);
 var tweeter = TwitterPoster(env);
 var log = helpers.logger('App', env.isDev);
 

--- a/app.js
+++ b/app.js
@@ -3,7 +3,7 @@ var https = require('https');
 var url = require('url');
 var assign = require('lodash.assign');
 var concat = require('concat-stream');
-var Slackbot = require('./slackbot');
+var slackbot = require('./slackbot');
 var TwitterPoster = require('./twitter');
 var createFakeScreenshot = require('./create-fake-screenshot');
 var helpers = require('./helpers');
@@ -15,7 +15,14 @@ require('dotenv').config({
   silent: env.vars.NODE_ENV !== 'development'
 });
 
-var bot = Slackbot(env);
+var bot = (function () {
+  var rtm = slackbot.getSlackRtmClient(env);
+  var web = slackbot.getSlackWebClient(env);
+  var verbose = slackbot.getLogger(env);
+  return slackbot.Slackbot(rtm, web, verbose);
+})();
+
+// var bot = Slackbot(env);
 var tweeter = TwitterPoster(env);
 var log = helpers.logger('App', env.isDev);
 

--- a/slackbot.js
+++ b/slackbot.js
@@ -7,51 +7,51 @@ function withDefaultOptions (env, options) {
   return options ? defaultOpts : assign(defaultOpts, options);
 }
 
-module.exports = {
-  Slackbot: function (transport, env, options) {
-    var mergedOptions = withDefaultOptions(env, options);
-    var rtm = new transport.RtmClient(env.vars.SLACK_TOKEN, mergedOptions);
-    var web = new transport.WebClient(env.vars.SLACK_TOKEN, mergedOptions);
-    var logger = helpers.logger('Slackbot', mergedOptions.logLevel === 'verbose');
+function Slackbot (transport, env, options) {
+  var mergedOptions = withDefaultOptions(env, options);
+  var rtm = new transport.RtmClient(env.vars.SLACK_TOKEN, mergedOptions);
+  var web = new transport.WebClient(env.vars.SLACK_TOKEN, mergedOptions);
+  var logger = helpers.logger('Slackbot', mergedOptions.logLevel === 'verbose');
 
-    function includeChannel (next) {
-      var yak = logger.sub('includeChannel');
-      return function addChannelToResponse (response) {
-        if (!response.channel_id) {
-          yak('no channel_id found, will not place call', response);
-          return next(response);
-        }
-        yak('channel_id found in response, get info for', response.channel_id);
-        return web.channels.info(
-          response.channel_id,
-          helpers.handleError(function (channelRes) {
-            yak('channel response for', response.channel_id, channelRes);
-            next(response, channelRes);
-          }));
-      };
-    }
-    function getFileInfo (id, next) {
-      var yak = logger.sub('getFileInfo');
-      yak('getting file', id);
-      web.files.info(id, helpers.handleError(function (res) {
-        yak('received file', res.file);
-        next(res.file);
-      }));
-    }
-    function onPinAdded (next) {
-      rtm.on(slack.RTM_EVENTS.PIN_ADDED, includeChannel(function (res, chan) {
-        logger('onPinAdded', res);
-        next.call(this, res, chan);
-      }));
-    }
-    function connect (next) {
-      rtm.on(slack.CLIENT_EVENTS.RTM.AUTHENTICATED, next);
-      rtm.start();
-    }
-    return {
-      getFileInfo: getFileInfo,
-      onPinAdded: onPinAdded,
-      connect: connect
+  function includeChannel (next) {
+    var yak = logger.sub('includeChannel');
+    return function addChannelToResponse (response) {
+      if (!response.channel_id) {
+        yak('no channel_id found, will not place call', response);
+        return next(response);
+      }
+      yak('channel_id found in response, get info for', response.channel_id);
+      return web.channels.info(
+        response.channel_id,
+        helpers.handleError(function (channelRes) {
+          yak('channel response for', response.channel_id, channelRes);
+          next(response, channelRes);
+        }));
     };
   }
-};
+  function getFileInfo (id, next) {
+    var yak = logger.sub('getFileInfo');
+    yak('getting file', id);
+    web.files.info(id, helpers.handleError(function (res) {
+      yak('received file', res.file);
+      next(res.file);
+    }));
+  }
+  function onPinAdded (next) {
+    rtm.on(slack.RTM_EVENTS.PIN_ADDED, includeChannel(function (res, chan) {
+      logger('onPinAdded', res);
+      next.call(this, res, chan);
+    }));
+  }
+  function connect (next) {
+    rtm.on(slack.CLIENT_EVENTS.RTM.AUTHENTICATED, next);
+    rtm.start();
+  }
+  return {
+    getFileInfo: getFileInfo,
+    onPinAdded: onPinAdded,
+    connect: connect
+  };
+}
+
+module.exports = Slackbot;

--- a/slackbot.js
+++ b/slackbot.js
@@ -2,27 +2,20 @@ var slack = require('@slack/client');
 var assign = require('lodash.assign');
 var helpers = require('./helpers');
 
-function clientOptions (env, options) {
+function withDefaultOptions (env, options) {
   var defaultOpts = env.isProd ? {} : { logLevel: 'verbose' };
   return options ? defaultOpts : assign(defaultOpts, options);
 }
 
-var exports = {
-  getSlackRtmClient: function (env, options) {
-    var clientOpts = clientOptions(env, options);
-    return new slack.RtmClient(env.vars.SLACK_TOKEN, clientOpts);
-  },
-  getSlackWebClient: function (env, options) {
-    var clientOpts = clientOptions(env, options);
-    return new slack.WebClient(env.vars.SLACK_TOKEN, clientOpts);
-  },
-  getLogger: function (env, options) {
-    var clientOpts = clientOptions(env, options);
-    return helpers.logger('Slackbot', clientOpts.logLevel === 'verbose');
-  },
-  Slackbot: function (rtm, web, verbose) {
+module.exports = {
+  Slackbot: function (transport, env, options) {
+    var mergedOptions = withDefaultOptions(env, options);
+    var rtm = new transport.RtmClient(env.vars.SLACK_TOKEN, mergedOptions);
+    var web = new transport.WebClient(env.vars.SLACK_TOKEN, mergedOptions);
+    var logger = helpers.logger('Slackbot', mergedOptions.logLevel === 'verbose');
+
     function includeChannel (next) {
-      var yak = verbose.sub('includeChannel');
+      var yak = logger.sub('includeChannel');
       return function addChannelToResponse (response) {
         if (!response.channel_id) {
           yak('no channel_id found, will not place call', response);
@@ -38,7 +31,7 @@ var exports = {
       };
     }
     function getFileInfo (id, next) {
-      var yak = verbose.sub('getFileInfo');
+      var yak = logger.sub('getFileInfo');
       yak('getting file', id);
       web.files.info(id, helpers.handleError(function (res) {
         yak('received file', res.file);
@@ -47,7 +40,7 @@ var exports = {
     }
     function onPinAdded (next) {
       rtm.on(slack.RTM_EVENTS.PIN_ADDED, includeChannel(function (res, chan) {
-        verbose('onPinAdded', res);
+        logger('onPinAdded', res);
         next.call(this, res, chan);
       }));
     }
@@ -62,5 +55,3 @@ var exports = {
     };
   }
 };
-
-module.exports = exports;

--- a/slackbot.js
+++ b/slackbot.js
@@ -2,51 +2,65 @@ var slack = require('@slack/client');
 var assign = require('lodash.assign');
 var helpers = require('./helpers');
 
-function Slackbot (env, opts) {
+function clientOptions (env, options) {
   var defaultOpts = env.isProd ? {} : { logLevel: 'verbose' };
-  var clientOpts = opts ? defaultOpts : assign(defaultOpts, opts);
-  var verbose = helpers.logger('Slackbot', clientOpts.logLevel === 'verbose');
-  var rtm = new slack.RtmClient(env.vars.SLACK_TOKEN, clientOpts);
-  var web = new slack.WebClient(env.vars.SLACK_TOKEN, clientOpts);
-  function includeChannel (next) {
-    var yak = verbose.sub('includeChannel');
-    return function addChannelToResponse (response) {
-      if (!response.channel_id) {
-        yak('no channel_id found, will not place call', response);
-        return next(response);
-      }
-      yak('channel_id found in response, get info for', response.channel_id);
-      return web.channels.info(
-        response.channel_id,
-        helpers.handleError(function (channelRes) {
-          yak('channel response for', response.channel_id, channelRes);
-          next(response, channelRes);
-        }));
-    };
-  }
-  function getFileInfo (id, next) {
-    var yak = verbose.sub('getFileInfo');
-    yak('getting file', id);
-    web.files.info(id, helpers.handleError(function (res) {
-      yak('received file', res.file);
-      next(res.file);
-    }));
-  }
-  function onPinAdded (next) {
-    rtm.on(slack.RTM_EVENTS.PIN_ADDED, includeChannel(function (res, chan) {
-      verbose('onPinAdded', res);
-      next.call(this, res, chan);
-    }));
-  }
-  function connect (next) {
-    rtm.on(slack.CLIENT_EVENTS.RTM.AUTHENTICATED, next);
-    rtm.start();
-  }
-  return {
-    getFileInfo: getFileInfo,
-    onPinAdded: onPinAdded,
-    connect: connect
-  };
+  return options ? defaultOpts : assign(defaultOpts, options);
 }
 
-module.exports = Slackbot;
+var exports = {
+  getSlackRtmClient: function (env, options) {
+    var clientOpts = clientOptions(env, options);
+    return new slack.RtmClient(env.vars.SLACK_TOKEN, clientOpts);
+  },
+  getSlackWebClient: function (env, options) {
+    var clientOpts = clientOptions(env, options);
+    return new slack.WebClient(env.vars.SLACK_TOKEN, clientOpts);
+  },
+  getLogger: function (env, options) {
+    var clientOpts = clientOptions(env, options);
+    return helpers.logger('Slackbot', clientOpts.logLevel === 'verbose');
+  },
+  Slackbot: function (rtm, web, verbose) {
+    function includeChannel (next) {
+      var yak = verbose.sub('includeChannel');
+      return function addChannelToResponse (response) {
+        if (!response.channel_id) {
+          yak('no channel_id found, will not place call', response);
+          return next(response);
+        }
+        yak('channel_id found in response, get info for', response.channel_id);
+        return web.channels.info(
+          response.channel_id,
+          helpers.handleError(function (channelRes) {
+            yak('channel response for', response.channel_id, channelRes);
+            next(response, channelRes);
+          }));
+      };
+    }
+    function getFileInfo (id, next) {
+      var yak = verbose.sub('getFileInfo');
+      yak('getting file', id);
+      web.files.info(id, helpers.handleError(function (res) {
+        yak('received file', res.file);
+        next(res.file);
+      }));
+    }
+    function onPinAdded (next) {
+      rtm.on(slack.RTM_EVENTS.PIN_ADDED, includeChannel(function (res, chan) {
+        verbose('onPinAdded', res);
+        next.call(this, res, chan);
+      }));
+    }
+    function connect (next) {
+      rtm.on(slack.CLIENT_EVENTS.RTM.AUTHENTICATED, next);
+      rtm.start();
+    }
+    return {
+      getFileInfo: getFileInfo,
+      onPinAdded: onPinAdded,
+      connect: connect
+    };
+  }
+};
+
+module.exports = exports;


### PR DESCRIPTION
By making the actual slack rtm and web clients parameters to the Slackbot class, we can mock them for testing.